### PR TITLE
linux: add support for bind_phc

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -266,7 +266,7 @@ pub fn open_ip(
     }?;
     socket.bind(addr.to_sockaddr(PrivateToken))?;
     socket.set_nonblocking(true)?;
-    configure_timestamping(&socket, timestamping.into())?;
+    configure_timestamping(&socket, timestamping.into(), None)?;
 
     Ok(Socket {
         timestamp_mode: timestamping.into(),
@@ -289,7 +289,7 @@ pub fn connect_address(
     }?;
     socket.connect(addr.to_sockaddr(PrivateToken))?;
     socket.set_nonblocking(true)?;
-    configure_timestamping(&socket, timestamping.into())?;
+    configure_timestamping(&socket, timestamping.into(), None)?;
 
     Ok(Socket {
         timestamp_mode: timestamping.into(),

--- a/src/socket/fallback.rs
+++ b/src/socket/fallback.rs
@@ -5,6 +5,7 @@ use super::InterfaceTimestampMode;
 pub(super) fn configure_timestamping(
     _socket: &RawSocket,
     mode: InterfaceTimestampMode,
+    _bind_phc: Option<u32>,
 ) -> std::io::Result<()> {
     match mode {
         InterfaceTimestampMode::None => Ok(()),

--- a/src/socket/freebsd.rs
+++ b/src/socket/freebsd.rs
@@ -5,6 +5,7 @@ use super::InterfaceTimestampMode;
 pub(super) fn configure_timestamping(
     socket: &RawSocket,
     mode: InterfaceTimestampMode,
+    _bind_phc: Option<u32>,
 ) -> std::io::Result<()> {
     match mode {
         InterfaceTimestampMode::None => Ok(()),

--- a/src/socket/macos.rs
+++ b/src/socket/macos.rs
@@ -5,6 +5,7 @@ use super::InterfaceTimestampMode;
 pub(super) fn configure_timestamping(
     socket: &RawSocket,
     mode: InterfaceTimestampMode,
+    _bind_phc: Option<u32>,
 ) -> std::io::Result<()> {
     match mode {
         InterfaceTimestampMode::None => Ok(()),


### PR DESCRIPTION
On `linux` it is possible to create [multiple PTP virtual clocks](https://lwn.net/Articles/859792/) using the sysfs.
In this case we need to specify the phc index (virtual clock) we want to use for receiving hardware timestamps.