### PR TITLE
Implement support for multiple local addresses on the same socket

### DIFF
--- a/src/control_message.rs
+++ b/src/control_message.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use std::{marker::PhantomData, net::IpAddr};
 
 use crate::socket::Timestamp;
 
@@ -95,6 +95,8 @@ pub(crate) enum ControlMessage {
     },
     #[cfg(target_os = "linux")]
     ReceiveError(libc::sock_extended_err),
+    #[expect(unused)]
+    DestinationIp(IpAddr),
     Other(libc::cmsghdr),
 }
 

--- a/src/control_message.rs
+++ b/src/control_message.rs
@@ -14,6 +14,7 @@ const RECEIVERR_CMSG_SIZE: usize =
 const IP_PKTINFO_CMSG_SIZE: usize = control_message_space::<libc::in_pktinfo>();
 #[cfg(any(target_os = "freebsd", target_os = "macos"))]
 const IP_RECVDSTADDR_CMSG_SIZE: usize = control_message_space::<libc::in_addr>();
+const IP6_PKTINFO_CMSG_SIZE: usize = control_message_space::<libc::in6_pktinfo>();
 
 // Utility needed since the ord trait max function is not usable in const environments
 const fn max(a: usize, b: usize) -> usize {
@@ -25,18 +26,21 @@ const fn max(a: usize, b: usize) -> usize {
 }
 
 #[cfg(target_os = "linux")]
-pub(crate) const EXPECTED_MAX_CMSG_SIZE: usize = max(
-    max(SCM_TIMESTAMPING_CMSG_SIZE, SCM_TIMESTAMP_NS_CMSG_SIZE),
-    SCM_TIMESTAMP_CMSG_SIZE,
-) + IP_PKTINFO_CMSG_SIZE
-    + RECEIVERR_CMSG_SIZE;
+pub(crate) const EXPECTED_MAX_CMSG_SIZE: usize =
+    max(
+        max(SCM_TIMESTAMPING_CMSG_SIZE, SCM_TIMESTAMP_NS_CMSG_SIZE),
+        SCM_TIMESTAMP_CMSG_SIZE,
+    ) + max(IP_PKTINFO_CMSG_SIZE, IP6_PKTINFO_CMSG_SIZE)
+        + RECEIVERR_CMSG_SIZE;
 #[cfg(target_os = "freebsd")]
 pub(crate) const EXPECTED_MAX_CMSG_SIZE: usize =
-    max(SCM_TIMESTAMP_NS_CMSG_SIZE, SCM_TIMESTAMP_CMSG_SIZE) + IP_RECVDSTADDR_CMSG_SIZE;
+    max(SCM_TIMESTAMP_NS_CMSG_SIZE, SCM_TIMESTAMP_CMSG_SIZE)
+        + max(IP_RECVDSTADDR_CMSG_SIZE, IP6_PKTINFO_CMSG_SIZE);
 #[cfg(target_os = "macos")]
-pub(crate) const EXPECTED_MAX_CMSG_SIZE: usize = SCM_TIMESTAMP_CMSG_SIZE + IP_RECVDSTADDR_CMSG_SIZE;
+pub(crate) const EXPECTED_MAX_CMSG_SIZE: usize =
+    SCM_TIMESTAMP_CMSG_SIZE + max(IP_RECVDSTADDR_CMSG_SIZE, IP6_PKTINFO_CMSG_SIZE);
 #[cfg(not(any(target_os = "linux", target_os = "freebsd", target_os = "macos")))]
-pub(crate) const EXPECTED_MAX_CMSG_SIZE: usize = SCM_TIMESTAMP_CMSG_SIZE;
+pub(crate) const EXPECTED_MAX_CMSG_SIZE: usize = SCM_TIMESTAMP_CMSG_SIZE + IP6_PKTINFO_CMSG_SIZE;
 
 const fn control_message_space<T>() -> usize {
     // Safety: CMSG_SPACE is safe to call
@@ -235,6 +239,22 @@ impl Iterator for ControlMessageIterator<'_> {
 
                 ControlMessage::DestinationIp(
                     std::net::Ipv4Addr::from_bits(u32::from_be(in_addr.s_addr)).into(),
+                )
+            }
+
+            (libc::IPPROTO_IPV6, libc::IPV6_PKTINFO) => {
+                // Safety:
+                // current_msg was constructed from a pointer that pointed to a valid
+                // control message.
+                // IPV6_PKTINFO always has a in6_pktinfo in the data
+                let pktinfo = unsafe {
+                    let ptr = libc::CMSG_DATA(current_msg) as *const libc::in6_pktinfo;
+                    std::ptr::read_unaligned(ptr)
+                };
+
+                ControlMessage::DestinationIp(
+                    std::net::Ipv6Addr::from_bits(u128::from_be_bytes(pktinfo.ipi6_addr.s6_addr))
+                        .into(),
                 )
             }
 

--- a/src/networkaddress.rs
+++ b/src/networkaddress.rs
@@ -24,7 +24,7 @@ pub(crate) mod sealed {
     pub struct PrivateToken;
 }
 
-pub trait NetworkAddress: Sized + SealedNA {
+pub trait NetworkAddress: Copy + Sized + SealedNA {
     #[doc(hidden)]
     fn to_sockaddr(&self, _token: PrivateToken) -> libc::sockaddr_storage;
     #[doc(hidden)]

--- a/src/networkaddress/linux.rs
+++ b/src/networkaddress/linux.rs
@@ -120,6 +120,15 @@ impl NetworkAddress for EthernetAddress {
             input.sll_ifindex,
         ))
     }
+
+    fn from_ip_and_port(_addr: std::net::IpAddr, _port: u16) -> Option<Self> {
+        None
+    }
+
+    fn port(&self) -> u16 {
+        // Ethernet doesn't have a port, zero is a decent sentinal value to cover that.
+        0
+    }
 }
 
 impl SealedMC for EthernetAddress {}

--- a/src/raw_socket.rs
+++ b/src/raw_socket.rs
@@ -45,6 +45,25 @@ impl RawSocket {
         })
     }
 
+    pub(crate) fn enable_destination_ipv6(&self) -> std::io::Result<()> {
+        // SAFETY:
+        //
+        // - the socket is provided by (safe) rust, and will outlive the call
+        // - method is guaranteed to be a valid "name" argument
+        // - the options pointer outlives the call
+        // - the `option_len` corresponds with the options pointer
+        unsafe {
+            cerr(libc::setsockopt(
+                self.fd,
+                libc::IPPROTO_IPV6,
+                libc::IPV6_RECVPKTINFO,
+                &(1 as libc::c_int) as *const _ as *const libc::c_void,
+                std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+            ))?;
+        }
+        Ok(())
+    }
+
     pub(crate) fn bind(&self, addr: sockaddr_storage) -> std::io::Result<()> {
         // Per posix, it may be invalid to specify a length larger than that of the family.
         let len = sockaddr_len(addr);

--- a/src/raw_socket.rs
+++ b/src/raw_socket.rs
@@ -12,6 +12,8 @@ use crate::{
     },
 };
 
+#[cfg(any(target_os = "macos", target_os = "freebsd"))]
+mod bsdlike;
 #[cfg(target_os = "freebsd")]
 mod freebsd;
 #[cfg(target_os = "linux")]

--- a/src/raw_socket.rs
+++ b/src/raw_socket.rs
@@ -14,6 +14,8 @@ use crate::{
 
 #[cfg(any(target_os = "macos", target_os = "freebsd"))]
 mod bsdlike;
+#[cfg(not(any(target_os = "macos", target_os = "freebsd", target_os = "linux")))]
+mod fallback;
 #[cfg(target_os = "freebsd")]
 mod freebsd;
 #[cfg(target_os = "linux")]

--- a/src/raw_socket.rs
+++ b/src/raw_socket.rs
@@ -1,9 +1,11 @@
 use std::{
     io::IoSliceMut,
+    mem::transmute,
     os::fd::{AsRawFd, RawFd},
+    ptr::write_unaligned,
 };
 
-use libc::{c_void, sockaddr, sockaddr_storage};
+use libc::{c_void, in6_addr, sockaddr, sockaddr_in, sockaddr_in6, sockaddr_storage};
 
 use crate::{
     cerr,
@@ -218,6 +220,108 @@ impl RawSocket {
         Ok(())
     }
 
+    pub(crate) fn send_from_to(
+        &self,
+        msg: &[u8],
+        from: sockaddr_storage,
+        to: sockaddr_storage,
+    ) -> std::io::Result<()> {
+        match from.ss_family as libc::c_int {
+            libc::AF_INET => {
+                // Safety:
+                // Transmuting &sockaddr_storage into another sockaddr reference type is safe, and in this case the lifetimes work out.
+                let from = unsafe { transmute::<&sockaddr_storage, &sockaddr_in>(&from) };
+                self.send_from_to_v4(msg, from.sin_addr, to)
+            }
+            libc::AF_INET6 => {
+                // Safety:
+                // Transmuting &sockaddr_storage into another sockaddr reference type is safe, and in this case the lifetimes work out.
+                let from = unsafe { transmute::<&sockaddr_storage, &sockaddr_in6>(&from) };
+                self.send_from_to_v6(msg, from.sin6_addr, to)
+            }
+            _ => Err(std::io::ErrorKind::InvalidInput.into()),
+        }
+    }
+
+    pub(crate) fn send_from(&self, msg: &[u8], addr: sockaddr_storage) -> std::io::Result<()> {
+        match addr.ss_family as libc::c_int {
+            libc::AF_INET => {
+                // Safety:
+                // Transmuting &sockaddr_storage into another sockaddr reference type is safe, and in this case the lifetimes work out.
+                let from = unsafe { transmute::<&sockaddr_storage, &sockaddr_in>(&addr) };
+                self.send_from_v4(msg, from.sin_addr)
+            }
+            libc::AF_INET6 => {
+                // Safety:
+                // Transmuting &sockaddr_storage into another sockaddr reference type is safe, and in this case the lifetimes work out.
+                let from = unsafe { transmute::<&sockaddr_storage, &sockaddr_in6>(&addr) };
+                self.send_from_v6(msg, from.sin6_addr)
+            }
+            _ => Err(std::io::ErrorKind::InvalidInput.into()),
+        }
+    }
+
+    pub(crate) fn send_from_v6(&self, msg: &[u8], addr: in6_addr) -> std::io::Result<()> {
+        let control_message = control_message(
+            libc::IPPROTO_IPV6,
+            libc::IPV6_PKTINFO,
+            libc::in6_pktinfo {
+                ipi6_addr: addr,
+                ipi6_ifindex: 0,
+            },
+        );
+
+        let mut iov = libc::iovec {
+            iov_base: msg.as_ptr() as *mut libc::c_void,
+            iov_len: msg.len(),
+        };
+
+        let mut msghdr = empty_msghdr();
+        msghdr.msg_iov = &raw mut iov;
+        msghdr.msg_iovlen = 1;
+        msghdr.msg_control = control_message.as_ptr() as *mut _;
+        msghdr.msg_controllen = control_message.len() as _;
+
+        // Safety:
+        // msghdr is valid.
+        cerr(unsafe { libc::sendmsg(self.fd, &raw const msghdr, 0) } as _).map(|_| {})
+    }
+
+    pub(crate) fn send_from_to_v6(
+        &self,
+        msg: &[u8],
+        from: in6_addr,
+        to: sockaddr_storage,
+    ) -> std::io::Result<()> {
+        let to_len = sockaddr_len(to);
+
+        let control_message = control_message(
+            libc::IPPROTO_IPV6,
+            libc::IPV6_PKTINFO,
+            libc::in6_pktinfo {
+                ipi6_addr: from,
+                ipi6_ifindex: 0,
+            },
+        );
+
+        let mut iov = libc::iovec {
+            iov_base: msg.as_ptr() as *mut libc::c_void,
+            iov_len: msg.len(),
+        };
+
+        let mut msghdr = empty_msghdr();
+        msghdr.msg_name = &raw const to as *mut _;
+        msghdr.msg_namelen = to_len;
+        msghdr.msg_iov = &raw mut iov;
+        msghdr.msg_iovlen = 1;
+        msghdr.msg_control = control_message.as_ptr() as *mut _;
+        msghdr.msg_controllen = control_message.len() as _;
+
+        // Safety:
+        // msghdr is valid.
+        cerr(unsafe { libc::sendmsg(self.fd, &raw const msghdr, 0) } as _).map(|_| {})
+    }
+
     pub(crate) fn getsockname(&self) -> std::io::Result<sockaddr_storage> {
         let mut addr = zeroed_sockaddr_storage();
         let mut addr_len: libc::socklen_t = std::mem::size_of_val(&addr) as _;
@@ -261,6 +365,39 @@ fn sockaddr_len(addr: sockaddr_storage) -> u32 {
         libc::AF_INET6 => std::mem::size_of::<libc::sockaddr_in6>() as _,
         _ => len,
     })
+}
+
+// Generate a control message with T as its contents
+// Guarantees that the resulting vec contains valid control messages.
+fn control_message<T>(level: libc::c_int, type_: libc::c_int, content: T) -> Vec<u8> {
+    // Safety:
+    // libc::CMSG_SPACE is always safe to call.
+    let mut control_message = vec![0u8; unsafe { libc::CMSG_SPACE(size_of::<T>() as _) } as _];
+
+    // Safety:
+    // libc::CMSG_LEN is always safe to call.
+    let header = libc::cmsghdr {
+        cmsg_len: unsafe { libc::CMSG_LEN(size_of::<T>() as _) } as _,
+        cmsg_level: level,
+        cmsg_type: type_,
+    };
+    // Safety:
+    // libc::CMSG_SPACE ensures we have sufficient space for the control message header.
+    unsafe { write_unaligned(control_message.as_mut_ptr() as *mut libc::cmsghdr, header) };
+
+    // Safety:
+    // libc::CMSG_SPACE ensures we have sufficient space for the control message contents.
+    // libc::CMSG_DATA ensures we write that content at a valid offset.
+    // libc::CMSG_DATA provides a valid pointer to the contents of a control message when provided
+    // with a valid pointer to a control message header, which we have in the buffer.
+    unsafe {
+        write_unaligned(
+            libc::CMSG_DATA(control_message.as_mut_ptr() as *mut libc::cmsghdr) as *mut T,
+            content,
+        )
+    };
+
+    control_message
 }
 
 impl Drop for RawSocket {

--- a/src/raw_socket/bsdlike.rs
+++ b/src/raw_socket/bsdlike.rs
@@ -1,0 +1,22 @@
+use super::RawSocket;
+
+impl RawSocket {
+    pub(crate) fn enable_destination_ipv4(&self) -> std::io::Result<()> {
+        // SAFETY:
+        //
+        // - the socket is provided by (safe) rust, and will outlive the call
+        // - method is guaranteed to be a valid "name" argument
+        // - the options pointer outlives the call
+        // - the `option_len` corresponds with the options pointer
+        unsafe {
+            cerr(libc::setsockopt(
+                self.fd,
+                libc::IPPROTO_IP,
+                libc::IP_RECVDSTADDR,
+                &(1 as libc::c_int) as *const _ as *const libc::c_void,
+                std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+            ))?;
+        }
+        Ok(())
+    }
+}

--- a/src/raw_socket/bsdlike.rs
+++ b/src/raw_socket/bsdlike.rs
@@ -1,4 +1,8 @@
-use super::RawSocket;
+use libc::{in_addr, sockaddr_storage};
+
+use crate::{cerr, control_message::empty_msghdr, raw_socket::sockaddr_len};
+
+use super::{control_message, RawSocket};
 
 impl RawSocket {
     pub(crate) fn enable_destination_ipv4(&self) -> std::io::Result<()> {
@@ -18,5 +22,39 @@ impl RawSocket {
             ))?;
         }
         Ok(())
+    }
+
+    pub(crate) fn send_from_v4(&self, msg: &[u8], _addr: in_addr) -> std::io::Result<()> {
+        // FreeBSD and similar don't support setting an IPv4 source address
+        // on connected sockets.
+        self.send(msg)
+    }
+
+    pub(crate) fn send_from_to_v4(
+        &self,
+        msg: &[u8],
+        from: in_addr,
+        to: sockaddr_storage,
+    ) -> std::io::Result<()> {
+        let to_len = sockaddr_len(to);
+
+        let control_message = control_message(libc::IPPROTO_IP, libc::IP_SENDSRCADDR, from);
+
+        let mut iov = libc::iovec {
+            iov_base: msg.as_ptr() as *mut libc::c_void,
+            iov_len: msg.len(),
+        };
+
+        let mut msghdr = empty_msghdr();
+        msghdr.msg_name = &raw const to as *mut _;
+        msghdr.msg_namelen = to_len;
+        msghdr.msg_iov = &raw mut iov;
+        msghdr.msg_iovlen = 1;
+        msghdr.msg_control = control_message.as_ptr() as *mut _;
+        msghdr.msg_controllen = control_message.len() as _;
+
+        // Safety:
+        // msghdr is valid.
+        cerr(unsafe { libc::sendmsg(self.fd, &raw const msghdr, 0) } as _).map(|_| {})
     }
 }

--- a/src/raw_socket/fallback.rs
+++ b/src/raw_socket/fallback.rs
@@ -1,8 +1,25 @@
+use libc::{in_addr, sockaddr_storage};
+
 use super::RawSocket;
 
 impl RawSocket {
     pub(crate) fn enable_destination_ipv4(&self) -> std::io::Result<()> {
         // Noop, fallback to local address.
         Ok(())
+    }
+
+    pub(crate) fn send_from_v4(&self, msg: &[u8], addr: in_addr) -> std::io::Result<()> {
+        // Fallback, ignore the from
+        self.send(msg)
+    }
+
+    pub(crate) fn send_from_to_v4(
+        &self,
+        msg: &[u8],
+        from: in_addr,
+        to: sockaddr_storage,
+    ) -> std::io::Result<()> {
+        // Fallback, ignore the from
+        self.send_to(msg, to)
     }
 }

--- a/src/raw_socket/fallback.rs
+++ b/src/raw_socket/fallback.rs
@@ -1,0 +1,8 @@
+use super::RawSocket;
+
+impl RawSocket {
+    pub(crate) fn enable_destination_ipv4(&self) -> std::io::Result<()> {
+        // Noop, fallback to local address.
+        Ok(())
+    }
+}

--- a/src/raw_socket/linux.rs
+++ b/src/raw_socket/linux.rs
@@ -12,7 +12,21 @@ struct SoTimestamping {
 
 impl RawSocket {
     pub(crate) fn enable_destination_ipv4(&self) -> std::io::Result<()> {
-        // FIXME: Implement this
+        // SAFETY:
+        //
+        // - the socket is provided by (safe) rust, and will outlive the call
+        // - method is guaranteed to be a valid "name" argument
+        // - the options pointer outlives the call
+        // - the `option_len` corresponds with the options pointer
+        unsafe {
+            cerr(libc::setsockopt(
+                self.fd,
+                libc::IPPROTO_IP,
+                libc::IP_PKTINFO,
+                &(1 as libc::c_int) as *const _ as *const libc::c_void,
+                std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+            ))?;
+        }
         Ok(())
     }
 

--- a/src/raw_socket/linux.rs
+++ b/src/raw_socket/linux.rs
@@ -11,6 +11,11 @@ struct SoTimestamping {
 }
 
 impl RawSocket {
+    pub(crate) fn enable_destination_ipv4(&self) -> std::io::Result<()> {
+        // FIXME: Implement this
+        Ok(())
+    }
+
     pub(crate) fn so_timestamping(&self, options: u32, bind_phc: u32) -> std::io::Result<()> {
         // Documentation on the timestamping calls:
         //

--- a/src/raw_socket/linux.rs
+++ b/src/raw_socket/linux.rs
@@ -1,8 +1,12 @@
 use std::net::Ipv4Addr;
 
-use crate::{cerr, interface::InterfaceName};
+use libc::{in_addr, sockaddr_storage};
 
-use super::RawSocket;
+use crate::{
+    cerr, control_message::empty_msghdr, interface::InterfaceName, raw_socket::sockaddr_len,
+};
+
+use super::{control_message, RawSocket};
 
 #[repr(C)]
 struct SoTimestamping {
@@ -208,5 +212,68 @@ impl RawSocket {
             )
         })?;
         Ok(())
+    }
+
+    pub(crate) fn send_from_v4(&self, msg: &[u8], addr: in_addr) -> std::io::Result<()> {
+        let control_message = control_message(
+            libc::IPPROTO_IP,
+            libc::IP_PKTINFO,
+            libc::in_pktinfo {
+                ipi_ifindex: 0,
+                ipi_spec_dst: addr,
+                ipi_addr: libc::in_addr { s_addr: 0 },
+            },
+        );
+
+        let mut iov = libc::iovec {
+            iov_base: msg.as_ptr() as *mut libc::c_void,
+            iov_len: msg.len(),
+        };
+
+        let mut msghdr = empty_msghdr();
+        msghdr.msg_iov = &raw mut iov;
+        msghdr.msg_iovlen = 1;
+        msghdr.msg_control = control_message.as_ptr() as *mut _;
+        msghdr.msg_controllen = control_message.len() as _;
+
+        // Safety:
+        // msghdr is valid.
+        cerr(unsafe { libc::sendmsg(self.fd, &raw const msghdr, 0) } as _).map(|_| {})
+    }
+
+    pub(crate) fn send_from_to_v4(
+        &self,
+        msg: &[u8],
+        from: in_addr,
+        to: sockaddr_storage,
+    ) -> std::io::Result<()> {
+        let to_len = sockaddr_len(to);
+
+        let control_message = control_message(
+            libc::IPPROTO_IP,
+            libc::IP_PKTINFO,
+            libc::in_pktinfo {
+                ipi_ifindex: 0,
+                ipi_spec_dst: from,
+                ipi_addr: libc::in_addr { s_addr: 0 },
+            },
+        );
+
+        let mut iov = libc::iovec {
+            iov_base: msg.as_ptr() as *mut libc::c_void,
+            iov_len: msg.len(),
+        };
+
+        let mut msghdr = empty_msghdr();
+        msghdr.msg_name = &raw const to as *mut _;
+        msghdr.msg_namelen = to_len;
+        msghdr.msg_iov = &raw mut iov;
+        msghdr.msg_iovlen = 1;
+        msghdr.msg_control = control_message.as_ptr() as *mut _;
+        msghdr.msg_controllen = control_message.len() as _;
+
+        // Safety:
+        // msghdr is valid.
+        cerr(unsafe { libc::sendmsg(self.fd, &raw const msghdr, 0) } as _).map(|_| {})
     }
 }

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -3,7 +3,7 @@ use std::{marker::PhantomData, net::SocketAddr, os::fd::AsRawFd};
 use tokio::io::{unix::AsyncFd, Interest};
 
 use crate::{
-    control_message::{control_message_space, ControlMessage, MessageQueue},
+    control_message::{ControlMessage, MessageQueue, EXPECTED_MAX_CMSG_SIZE},
     interface::InterfaceName,
     networkaddress::{sealed::PrivateToken, MulticastJoinable, NetworkAddress},
     raw_socket::RawSocket,
@@ -124,7 +124,7 @@ impl<A: NetworkAddress, S> Socket<A, S> {
     pub async fn recv(&self, buf: &mut [u8]) -> std::io::Result<RecvResult<A>> {
         self.socket
             .async_io(Interest::READABLE, |socket| {
-                let mut control_buf = [0; control_message_space::<[libc::timespec; 3]>()];
+                let mut control_buf = [0; EXPECTED_MAX_CMSG_SIZE];
 
                 // loops for when we receive an interrupt during the recv
                 let (bytes_read, control_messages, remote_address) =

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -120,11 +120,6 @@ impl<A: NetworkAddress, S> Socket<A, S> {
         A::from_sockaddr(addr, PrivateToken).ok_or_else(|| std::io::ErrorKind::Other.into())
     }
 
-    pub fn peer_addr(&self) -> std::io::Result<A> {
-        let addr = self.socket.get_ref().getpeername()?;
-        A::from_sockaddr(addr, PrivateToken).ok_or_else(|| std::io::ErrorKind::Other.into())
-    }
-
     pub async fn recv(&self, buf: &mut [u8]) -> std::io::Result<RecvResult<A>> {
         self.socket
             .async_io(Interest::READABLE, |socket| {
@@ -219,6 +214,11 @@ impl<A: NetworkAddress> Socket<A, Open> {
 }
 
 impl<A: NetworkAddress> Socket<A, Connected> {
+    pub fn peer_addr(&self) -> std::io::Result<A> {
+        let addr = self.socket.get_ref().getpeername()?;
+        A::from_sockaddr(addr, PrivateToken).ok_or_else(|| std::io::ErrorKind::Other.into())
+    }
+
     pub async fn send(&mut self, buf: &[u8]) -> std::io::Result<Option<Timestamp>> {
         self.socket
             .async_io(Interest::WRITABLE, |socket| socket.send(buf))

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -276,7 +276,7 @@ pub fn open_ip(
     }?;
     match addr {
         SocketAddr::V4(_) => socket.enable_destination_ipv4()?,
-        SocketAddr::V6(_) => { /*FIXME: enable destination addresses for ipv6*/ }
+        SocketAddr::V6(_) => socket.enable_destination_ipv6()?,
     }
     socket.bind(addr.to_sockaddr(PrivateToken))?;
     socket.set_nonblocking(true)?;
@@ -306,7 +306,7 @@ pub fn connect_address(
     }?;
     match addr {
         SocketAddr::V4(_) => socket.enable_destination_ipv4()?,
-        SocketAddr::V6(_) => { /*FIXME: enable destination addresses for ipv6*/ }
+        SocketAddr::V6(_) => socket.enable_destination_ipv6()?,
     }
     socket.connect(addr.to_sockaddr(PrivateToken))?;
     socket.set_nonblocking(true)?;

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -111,7 +111,9 @@ pub struct Socket<A, S> {
     _state: PhantomData<S>,
 }
 
+#[non_exhaustive]
 pub struct Open;
+#[non_exhaustive]
 pub struct Connected;
 
 impl<A: NetworkAddress, S> Socket<A, S> {

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -274,6 +274,10 @@ pub fn open_ip(
         SocketAddr::V4(_) => RawSocket::open(libc::PF_INET, libc::SOCK_DGRAM, libc::IPPROTO_UDP),
         SocketAddr::V6(_) => RawSocket::open(libc::PF_INET6, libc::SOCK_DGRAM, libc::IPPROTO_UDP),
     }?;
+    match addr {
+        SocketAddr::V4(_) => socket.enable_destination_ipv4()?,
+        SocketAddr::V6(_) => { /*FIXME: enable destination addresses for ipv6*/ }
+    }
     socket.bind(addr.to_sockaddr(PrivateToken))?;
     socket.set_nonblocking(true)?;
     configure_timestamping(&socket, None, timestamping.into(), None)?;
@@ -300,6 +304,10 @@ pub fn connect_address(
         SocketAddr::V4(_) => RawSocket::open(libc::PF_INET, libc::SOCK_DGRAM, libc::IPPROTO_UDP),
         SocketAddr::V6(_) => RawSocket::open(libc::PF_INET6, libc::SOCK_DGRAM, libc::IPPROTO_UDP),
     }?;
+    match addr {
+        SocketAddr::V4(_) => socket.enable_destination_ipv4()?,
+        SocketAddr::V6(_) => { /*FIXME: enable destination addresses for ipv6*/ }
+    }
     socket.connect(addr.to_sockaddr(PrivateToken))?;
     socket.set_nonblocking(true)?;
     configure_timestamping(&socket, None, timestamping.into(), None)?;

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -209,6 +209,41 @@ impl<A: NetworkAddress> Socket<A, Open> {
         }
     }
 
+    pub async fn send_from_to(
+        &mut self,
+        buf: &[u8],
+        from: A,
+        to: A,
+    ) -> std::io::Result<Option<Timestamp>> {
+        let from = from.to_sockaddr(PrivateToken);
+        let to = to.to_sockaddr(PrivateToken);
+
+        self.socket
+            .async_io(Interest::WRITABLE, |socket| {
+                socket.send_from_to(buf, from, to)
+            })
+            .await?;
+
+        if matches!(
+            self.timestamp_mode,
+            InterfaceTimestampMode::HardwarePTPAll | InterfaceTimestampMode::SoftwareAll
+        ) {
+            #[cfg(target_os = "linux")]
+            {
+                let expected_counter = self.send_counter;
+                self.send_counter = self.send_counter.wrapping_add(1);
+                self.fetch_send_timestamp(expected_counter).await
+            }
+
+            #[cfg(not(target_os = "linux"))]
+            {
+                unreachable!("Should not be able to create send timestamping sockets on platforms other than linux")
+            }
+        } else {
+            Ok(None)
+        }
+    }
+
     pub fn connect(self, addr: A) -> std::io::Result<Socket<A, Connected>> {
         let addr = addr.to_sockaddr(PrivateToken);
         self.socket.get_ref().connect(addr)?;
@@ -232,6 +267,32 @@ impl<A: NetworkAddress> Socket<A, Connected> {
     pub async fn send(&mut self, buf: &[u8]) -> std::io::Result<Option<Timestamp>> {
         self.socket
             .async_io(Interest::WRITABLE, |socket| socket.send(buf))
+            .await?;
+
+        if matches!(
+            self.timestamp_mode,
+            InterfaceTimestampMode::HardwarePTPAll | InterfaceTimestampMode::SoftwareAll
+        ) {
+            #[cfg(target_os = "linux")]
+            {
+                let expected_counter = self.send_counter;
+                self.send_counter = self.send_counter.wrapping_add(1);
+                self.fetch_send_timestamp(expected_counter).await
+            }
+
+            #[cfg(not(target_os = "linux"))]
+            {
+                unreachable!("Should not be able to create send timestamping sockets on platforms other than linux")
+            }
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub async fn send_from(&mut self, buf: &[u8], from: A) -> std::io::Result<Option<Timestamp>> {
+        let from = from.to_sockaddr(PrivateToken);
+        self.socket
+            .async_io(Interest::WRITABLE, |socket| socket.send_from(buf, from))
             .await?;
 
         if matches!(
@@ -361,7 +422,7 @@ mod tests {
         )
         .unwrap();
         let mut b = connect_address(
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 1, 1)), 5127),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 5127),
             GeneralTimestampMode::None,
         )
         .unwrap();
@@ -372,8 +433,9 @@ mod tests {
         assert_eq!(&buf[0..3], &[1, 2, 3]);
         assert_eq!(
             recv_result.local_addr,
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 1, 1)), 5127)
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 5127)
         );
+        assert_ne!(a.local_addr().ip(), IpAddr::V4(Ipv4Addr::LOCALHOST));
 
         let a = open_ip(
             SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 5129),
@@ -393,6 +455,95 @@ mod tests {
         assert_eq!(
             recv_result.local_addr,
             SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 5129)
+        );
+        assert_ne!(a.local_addr().ip(), IpAddr::V6(Ipv6Addr::LOCALHOST));
+    }
+
+    #[tokio::test]
+    async fn test_send_from() {
+        let mut a = open_ip(
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 5130),
+            GeneralTimestampMode::None,
+        )
+        .unwrap();
+        let mut b = connect_address(
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 5130),
+            GeneralTimestampMode::None,
+        )
+        .unwrap();
+        b.send_from(
+            &[1, 2, 3],
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+        )
+        .await
+        .unwrap();
+        let mut buf = [0; 4];
+        let recv_result = a.recv(&mut buf).await.unwrap();
+        assert_eq!(recv_result.bytes_read, 3);
+        assert_eq!(&buf[0..3], &[1, 2, 3]);
+        assert_eq!(
+            recv_result.remote_addr.ip(),
+            IpAddr::V4(Ipv4Addr::LOCALHOST)
+        );
+
+        a.send_from_to(
+            &[1, 2, 3],
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+            dbg!(b.local_addr()),
+        )
+        .await
+        .unwrap();
+        let mut buf = [0; 4];
+        let recv_result = b.recv(&mut buf).await.unwrap();
+        assert_eq!(recv_result.bytes_read, 3);
+        assert_eq!(&buf[0..3], &[1, 2, 3]);
+        assert_eq!(
+            recv_result.remote_addr.ip(),
+            IpAddr::V4(Ipv4Addr::LOCALHOST)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_send_from_v6() {
+        let mut a = open_ip(
+            SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 5131),
+            GeneralTimestampMode::None,
+        )
+        .unwrap();
+        let mut b = connect_address(
+            SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 5131),
+            GeneralTimestampMode::None,
+        )
+        .unwrap();
+        b.send_from(
+            &[1, 2, 3],
+            SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 0),
+        )
+        .await
+        .unwrap();
+        let mut buf = [0; 4];
+        let recv_result = a.recv(&mut buf).await.unwrap();
+        assert_eq!(recv_result.bytes_read, 3);
+        assert_eq!(&buf[0..3], &[1, 2, 3]);
+        assert_eq!(
+            recv_result.remote_addr.ip(),
+            IpAddr::V6(Ipv6Addr::LOCALHOST)
+        );
+
+        a.send_from_to(
+            &[1, 2, 3],
+            SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 0),
+            dbg!(b.local_addr()),
+        )
+        .await
+        .unwrap();
+        let mut buf = [0; 4];
+        let recv_result = b.recv(&mut buf).await.unwrap();
+        assert_eq!(recv_result.bytes_read, 3);
+        assert_eq!(&buf[0..3], &[1, 2, 3]);
+        assert_eq!(
+            recv_result.remote_addr.ip(),
+            IpAddr::V6(Ipv6Addr::LOCALHOST)
         );
     }
 }

--- a/src/socket/linux.rs
+++ b/src/socket/linux.rs
@@ -164,6 +164,7 @@ pub fn open_interface_udp(
 ) -> std::io::Result<Socket<SocketAddr, Open>> {
     // Setup the socket
     let socket = RawSocket::open(libc::PF_INET6, libc::SOCK_DGRAM, libc::IPPROTO_UDP)?;
+    socket.enable_destination_ipv4()?;
     socket.reuse_addr()?;
     socket.ipv6_v6only(false)?;
     socket.bind(SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, port, 0, 0).to_sockaddr(PrivateToken))?;
@@ -206,6 +207,7 @@ pub fn open_interface_udp4(
 ) -> std::io::Result<Socket<SocketAddrV4, Open>> {
     // Setup the socket
     let socket = RawSocket::open(libc::PF_INET, libc::SOCK_DGRAM, libc::IPPROTO_UDP)?;
+    socket.enable_destination_ipv4()?;
     socket.reuse_addr()?;
     socket.bind(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, port).to_sockaddr(PrivateToken))?;
     socket.bind_to_device(interface)?;

--- a/src/socket/linux.rs
+++ b/src/socket/linux.rs
@@ -185,11 +185,14 @@ pub fn open_interface_udp(
     }
     socket.set_nonblocking(true)?;
 
+    let local_addr = SocketAddr::from_sockaddr(socket.getsockname()?, PrivateToken)
+        .ok_or::<std::io::Error>(std::io::ErrorKind::Other.into())?;
+
     Ok(Socket {
         timestamp_mode: timestamping,
         socket: AsyncFd::new(socket)?,
         send_counter: 0,
-        _addr: PhantomData,
+        local_addr,
         _state: PhantomData,
     })
 }
@@ -223,11 +226,14 @@ pub fn open_interface_udp4(
     }
     socket.set_nonblocking(true)?;
 
+    let local_addr = SocketAddrV4::from_sockaddr(socket.getsockname()?, PrivateToken)
+        .ok_or::<std::io::Error>(std::io::ErrorKind::Other.into())?;
+
     Ok(Socket {
         timestamp_mode: timestamping,
         socket: AsyncFd::new(socket)?,
         send_counter: 0,
-        _addr: PhantomData,
+        local_addr,
         _state: PhantomData,
     })
 }
@@ -262,11 +268,14 @@ pub fn open_interface_udp6(
     }
     socket.set_nonblocking(true)?;
 
+    let local_addr = SocketAddrV6::from_sockaddr(socket.getsockname()?, PrivateToken)
+        .ok_or::<std::io::Error>(std::io::ErrorKind::Other.into())?;
+
     Ok(Socket {
         timestamp_mode: timestamping,
         socket: AsyncFd::new(socket)?,
         send_counter: 0,
-        _addr: PhantomData,
+        local_addr,
         _state: PhantomData,
     })
 }
@@ -308,11 +317,14 @@ pub fn open_interface_ethernet(
     }
     socket.set_nonblocking(true)?;
 
+    let local_addr = EthernetAddress::from_sockaddr(socket.getsockname()?, PrivateToken)
+        .ok_or::<std::io::Error>(std::io::ErrorKind::Other.into())?;
+
     Ok(Socket {
         timestamp_mode: timestamping,
         socket: AsyncFd::new(socket)?,
         send_counter: 0,
-        _addr: PhantomData,
+        local_addr,
         _state: PhantomData,
     })
 }

--- a/src/socket/linux.rs
+++ b/src/socket/linux.rs
@@ -165,6 +165,7 @@ pub fn open_interface_udp(
     // Setup the socket
     let socket = RawSocket::open(libc::PF_INET6, libc::SOCK_DGRAM, libc::IPPROTO_UDP)?;
     socket.enable_destination_ipv4()?;
+    socket.enable_destination_ipv6()?;
     socket.reuse_addr()?;
     socket.ipv6_v6only(false)?;
     socket.bind(SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, port, 0, 0).to_sockaddr(PrivateToken))?;
@@ -249,6 +250,7 @@ pub fn open_interface_udp6(
 ) -> std::io::Result<Socket<SocketAddrV6, Open>> {
     // Setup the socket
     let socket = RawSocket::open(libc::PF_INET6, libc::SOCK_DGRAM, libc::IPPROTO_UDP)?;
+    socket.enable_destination_ipv6()?;
     socket.reuse_addr()?;
     socket.ipv6_v6only(true)?;
     socket.bind(SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, port, 0, 0).to_sockaddr(PrivateToken))?;

--- a/src/socket/linux.rs
+++ b/src/socket/linux.rs
@@ -90,6 +90,10 @@ impl<A: NetworkAddress, S> Socket<A, S> {
                     }
                 }
 
+                ControlMessage::DestinationIp(_) => {
+                    tracing::debug!("unexpected destination ip control message");
+                }
+
                 ControlMessage::Other(msg) => {
                     tracing::debug!(
                         msg.cmsg_level,


### PR DESCRIPTION
This adds support for getting the local destination address on a recv, and setting the local origin address on send. This is needed to properly support multi-homed servers in ntpd-rs.