### PR TITLE
Improve timestamp naming in recv operations.

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -105,7 +105,8 @@ pub struct RecvResult<A> {
     pub bytes_read: usize,
     pub remote_addr: A,
     pub local_addr: A,
-    pub timestamp: Option<Timestamp>,
+    /// The timestamp of the type requested when opening the socket.
+    pub selected_timestamp: Option<Timestamp>,
     pub full_timestamp_data: FullTimestampData,
 }
 
@@ -188,7 +189,7 @@ impl<A: NetworkAddress, S> Socket<A, S> {
                     bytes_read,
                     remote_addr,
                     local_addr,
-                    timestamp,
+                    selected_timestamp: timestamp,
                     full_timestamp_data,
                 })
             })

--- a/src/socket/linux.rs
+++ b/src/socket/linux.rs
@@ -505,7 +505,7 @@ mod tests {
 
         let mut buf = [0; 4];
         let recv_result = a.recv(&mut buf).await.unwrap();
-        let recv_ts = recv_result.timestamp.unwrap();
+        let recv_ts = recv_result.selected_timestamp.unwrap();
 
         let before = before
             .duration_since(SystemTime::UNIX_EPOCH)


### PR DESCRIPTION
Closes #177 